### PR TITLE
return the interactive namespace for use in third-party libraries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
 * New attribute ``Client.context`` to set the default context for
   all RPC calls.
 
+* Return the interactive namespace with ``main(interact=False)``.
+  It helps to integrate with third-party libraries, such as IPython.
+
 * Remove a duplicate ``Logged in as ...`` line in interactive mode.
 
 * Remove the ``search+name_get`` undocumented feature which has

--- a/erppeek.py
+++ b/erppeek.py
@@ -1553,7 +1553,7 @@ def _interact(global_vars, use_pprint=True, usage=USAGE):
     Console().interact('\033[A')
 
 
-def main():
+def main(interact=_interact):
     description = ('Inspect data on Odoo objects.  Use interactively '
                    'or query a model (-m) and pass search terms or '
                    'ids as positional parameters after the options.')
@@ -1626,7 +1626,7 @@ def main():
         if not client.user:
             client.connect()
         # Enter interactive mode
-        _interact(global_vars)
+        return interact(global_vars) if interact else global_vars
 
 if __name__ == '__main__':
     main()

--- a/tests/test_interact.py
+++ b/tests/test_interact.py
@@ -31,6 +31,7 @@ class TestInteract(XmlRpcTestCase):
         mock.patch('erppeek.Client._set_interactive', wraps=erppeek.Client._set_interactive).start()
         self.interact = mock.patch('erppeek._interact', wraps=erppeek._interact).start()
         self.infunc = mock.patch('code.InteractiveConsole.raw_input').start()
+        mock.patch('erppeek.main.__defaults__', (self.interact,)).start()
 
     def test_main(self):
         env_tuple = ('http://127.0.0.1:8069', 'database', 'usr', None)


### PR DESCRIPTION
An alternative proposal to integrate with IPython and other libraries.
This should be enough to support IPython usage, as described in issue #51.

Then you could probably setup your IPython environment with:

``` python
import erppeek
import IPython

def main():
    global_vars = erppeek.main(interact=False)
    if global_vars:
        IPython.start_ipython(user_ns=global_vars, argv=[])

main()
```

I prefer this implementation because it does not rely explicitly on IPython. It is more generic.
