### PR TITLE
[IMP] add support for country_code in create_database (9.0+)

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -30,7 +30,14 @@ list or install Odoo add-ons.
 
 .. automethod:: Client.from_config
 
-.. automethod:: Client.create_database
+.. automethod:: Client.create_database(passwd, database, demo=False, lang='en_US', user_password='admin', country_code=None)
+
+   Create a new database.
+  
+   The superadmin `passwd` and the `database` name are mandatory.
+   By default, `demo` data are not loaded, `lang` is ``en_US``,
+   and no country is set into the database.
+   Wait for the thread to finish and login if successful.
 
 .. automethod:: Client.login
 

--- a/erppeek.py
+++ b/erppeek.py
@@ -636,7 +636,7 @@ class Client(object):
         return global_vars
 
     def create_database(self, passwd, database, demo=False, lang='en_US',
-                        user_password='admin'):
+                        user_password='admin', country_code=None):
         """Create a new database.
 
         The superadmin `passwd` and the `database` name are mandatory.
@@ -653,9 +653,12 @@ class Client(object):
                     progress, users = self.db.get_progress(passwd, thread_id)
             except KeyboardInterrupt:
                 return {'id': thread_id, 'progress': progress}
-        else:
+        elif self.major_version in ('7.0', '8.0'):
             self.db.create_database(passwd, database, demo, lang,
                                     user_password)
+        else:
+            self.db.create_database(passwd, database, demo, lang,
+                                    user_password, 'admin', country_code)
         return self.login('admin', user_password, database=database)
 
     def execute(self, obj, method, *params, **kwargs):

--- a/erppeek.py
+++ b/erppeek.py
@@ -640,7 +640,8 @@ class Client(object):
         """Create a new database.
 
         The superadmin `passwd` and the `database` name are mandatory.
-        By default, `demo` data are not loaded and `lang` is ``en_US``.
+        By default, `demo` data are not loaded, `lang` is ``en_US``
+        and no country is set into the database.
         Wait for the thread to finish and login if successful.
         """
         if self.major_version in ('5.0', '6.0'):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -306,13 +306,13 @@ class TestClientApi(XmlRpcTestCase):
         self.client.db.list.side_effect = [['db1'], ['db2']]
 
         create_database('abc', 'db1')
-        create_database('xyz', 'db2', user_password='secret', lang='fr_FR')
+        create_database('xyz', 'db2', user_password='secret', lang='fr_FR', country_code='CA')
 
         self.assertCalls(
-            call.db.create_database('abc', 'db1', False, 'en_US', 'admin'),
+            call.db.create_database('abc', 'db1', False, 'en_US', 'admin', 'admin', None),
             call.db.list(),
             call.common.login('db1', 'admin', 'admin'),
-            call.db.create_database('xyz', 'db2', False, 'fr_FR', 'secret'),
+            call.db.create_database('xyz', 'db2', False, 'fr_FR', 'secret', 'admin', 'CA'),
             call.db.list(),
             call.common.login('db2', 'admin', 'secret'),
         )


### PR DESCRIPTION
This appeared in Odoo 9. It's now mendatory in Odoo 10 because
otherwise, when installing the accounting module, Odoo complains about
missing chart of account.