### PR TITLE
[FIX] change regex method to allow odoo saas

### DIFF
--- a/erppeek.py
+++ b/erppeek.py
@@ -517,7 +517,7 @@ class Client(object):
 
         float_version = 99.0
         self.server_version = ver = get_service('db').server_version()
-        self.major_version = re.match(r'\d+\.?\d*', ver).group()
+        self.major_version = re.search(r'\d+\.?\d*', ver).group()
         float_version = float(self.major_version)
         # Create the RPC services
         self.db = get_service('db')


### PR DESCRIPTION
https://github.com/tinyerp/erppeek/blob/9a43eb9a07919db90ed8b8f2350f96a45bc63df1/erppeek.py#L520

The regex seems not to work with the "match" method (the saas odoo version is something like saas~15.2+e).

`AttributeError: 'NoneType' object has no attribute 'group'`

If you change "match" to "search", it works with the saas version.